### PR TITLE
Mynewt 1.6.0 compatibility

### DIFF
--- a/test/pkg.yml
+++ b/test/pkg.yml
@@ -29,3 +29,4 @@ pkg.deps:
 
 pkg.deps.SELFTEST:
     - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/stub"

--- a/test/src/interpolate_test_priv.h
+++ b/test/src/interpolate_test_priv.h
@@ -30,7 +30,7 @@
 extern "C" {
 #endif
 
-int intpl_fmt_test_suite(void);
+TEST_SUITE_DECL(intpl_fmt_test_suite);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The Mynewt `testutil` library is going through some changes.  I was using the unit test package in this repo to verify that the Mynewt changes are backwards incompatible.  In the process, I noticed a few other things that will break with the next release of Mynewt (1.6).